### PR TITLE
set mimeType in uploadFile.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   dio: ^5.0.0
   dio_cookie_manager: ^3.0.0
   cookie_jar: ^4.0.0
-
+  mime: ^2.0.0
+  http_parser: ^4.1.2
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Hello. This repository always helps me.

When uploading a file to dify using the current implementation of the uploadFile function, there is no code to explicitly set the MimeType.

As a result, the Content-Type of the file uploaded to dify becomes "application/octet-stream".

If the Content-Type remains "application/octet-stream" and is used for LLM such as GPT4o, an error will occur.

This PR, the uploadFile function determines the MimeType from the file path, and if it is not null, set mimeType in uploadFile method.

Since the specifications for the mimetype of attachments in dify have not been made public, I cannot say whether this implementation is necessarily correct.
However, in my case, I have been able to upload images using this code and successfully use the dify chat workflow that uses those images.

I hope this is helpful.